### PR TITLE
Add unit tests for list, and scrub actions

### DIFF
--- a/src/manifests.py
+++ b/src/manifests.py
@@ -271,15 +271,15 @@ class Manifests(abc.ABC):
         result: Mapping[_NamespaceKind, Set[HashableResource]] = defaultdict(set)
         for key, resources in self.resources.items():
             for obj in resources:
-                result[key].add(
-                    HashableResource(
-                        self.client.get(
-                            type(obj.resource),
-                            obj.name,
-                            namespace=obj.namespace,
-                        ),
+                try:
+                    next_rsc = self.client.get(
+                        type(obj.resource),
+                        obj.name,
+                        namespace=obj.namespace,
                     )
-                )
+                except ApiError:
+                    continue
+                result[key].add(HashableResource(next_rsc))
         return result
 
     def active_resources(self) -> Mapping[_NamespaceKind, Set[HashableResource]]:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -3,9 +3,21 @@
 import unittest.mock as mock
 
 import pytest
+from lightkube import ApiError
 
 
 @pytest.fixture(autouse=True)
 def lk_client():
     with mock.patch("manifests.Client") as mock_lightkube:
         yield mock_lightkube
+
+
+@pytest.fixture()
+def api_error_klass():
+    class TestApiError(ApiError):
+        status = mock.MagicMock()
+
+        def __init__(self):
+            pass
+
+    yield TestApiError

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -161,14 +161,14 @@ def test_waits_for_config(harness, lk_client, caplog):
             "control-node-selector": 'gcp.io/my-control-node=""',
         }
     )
-    provider_messages = [r.message for r in caplog.records if "provider" in r.filename]
+    provider_messages = {r.message for r in caplog.records if "provider" in r.filename}
 
-    assert provider_messages == [
+    assert provider_messages == {
         'Applying provider Control Node Selector as gcp.io/my-control-node: ""',
         "Replacing default cluster-name to kubernetes-thing",
         "Applying provider secret data",
         "Setting wait-routes=false",
-    ]
+    }
 
     caplog.clear()
     harness.update_config(
@@ -177,14 +177,14 @@ def test_waits_for_config(harness, lk_client, caplog):
             "image-registry": "dockerhub.io",
         }
     )
-    provider_messages = [r.message for r in caplog.records if "provider" in r.filename]
+    provider_messages = {r.message for r in caplog.records if "provider" in r.filename}
 
-    assert provider_messages == [
+    assert provider_messages == {
         'Applying provider Control Node Selector as juju-application: "kubernetes-control-plane"',
         "Replacing default cluster-name to kubernetes-thing",
         "Applying provider secret data",
         "Setting wait-routes=false",
-    ]
+    }
 
 
 @pytest.fixture()

--- a/tests/unit/test_manifests.py
+++ b/tests/unit/test_manifests.py
@@ -5,7 +5,6 @@ import unittest.mock as mock
 from collections import namedtuple
 
 import pytest
-from lightkube import ApiError
 
 from manifests import HashableResource, Manifests, _NamespaceKind
 
@@ -153,17 +152,6 @@ def test_delete_current_resources(test_manifest, caplog):
     mock_client.delete.assert_any_call(
         type(element.resource), "test-manifest-secret", namespace="kube-system"
     )
-
-
-@pytest.fixture()
-def api_error_klass():
-    class TestApiError(ApiError):
-        status = mock.MagicMock()
-
-        def __init__(self):
-            pass
-
-    yield TestApiError
 
 
 @pytest.mark.parametrize(

--- a/tox.ini
+++ b/tox.ini
@@ -68,6 +68,7 @@ description = Run unit tests
 deps =
     pytest
     pytest-cov
+    pytest-asyncio
     ipdb
     -r{toxinidir}/requirements.txt
 commands =


### PR DESCRIPTION
Testing the charm actions (which really should be pulled into a library with the `manifest.py` class)
* scrub_resources
* list_resources
