### PR TITLE
Cherry-picking for 1.26+ck1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,12 @@ jobs:
           sudo lxc network set lxdbr0 ipv6.address none
           sudo usermod -a -G lxd $USER
           sg lxd -c 'lxc version'
+      - name: Remove Docker
+        run: |
+          # https://github.com/canonical/lxd-cloud/blob/f20a64a8af42485440dcbfd370faf14137d2f349/test/includes/lxd.sh#L13-L23
+          sudo rm -rf /etc/docker
+          sudo apt-get purge moby-buildx moby-engine moby-cli moby-compose moby-containerd moby-runc -y
+          sudo iptables -P FORWARD ACCEPT
       - name: Install Charmcraft
         run: |
           sudo snap install charmcraft --classic --channel=latest/stable

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ lightkube>=0.10.1,<1.0.0
 jsonschema
 ops>=1.3.0,<2.0.0
 pyyaml
-git+https://github.com/canonical/ops-lib-manifest.git@602eb96dcfa54269505923b28d861771879c703d
+git+https://github.com/canonical/ops-lib-manifest.git@d8011cbd96c63257fffe76e979ac4b06da9b4fda
 git+https://github.com/charmed-kubernetes/interface-kube-control.git@6dd289d1c795fdeda1bed17873b8d6562227c829#subdirectory=ops

--- a/src/charm.py
+++ b/src/charm.py
@@ -10,7 +10,7 @@ from ops.charm import CharmBase
 from ops.framework import StoredState
 from ops.interface_kube_control import KubeControlRequirer
 from ops.main import main
-from ops.manifests import Collector
+from ops.manifests import Collector, ManifestClientError
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 
 from config import CharmConfig
@@ -105,7 +105,11 @@ class AzureCloudProviderCharm(CharmBase):
     def _sync_resources(self, event):
         manifests = event.params.get("controller", "")
         resources = event.params.get("resources", "")
-        return self.collector.apply_missing_resources(event, manifests, resources)
+        try:
+            self.collector.apply_missing_resources(event, manifests, resources)
+        except ManifestClientError:
+            msg = "Failed to apply missing resources. API Server unavailable."
+            event.set_results({"result": msg})
 
     def _update_status(self, _):
         if not self.stored.deployed:
@@ -119,11 +123,11 @@ class AzureCloudProviderCharm(CharmBase):
             self.unit.set_workload_version(self.collector.short_version)
             self.app.status = ActiveStatus(self.collector.long_version)
 
-    def _kube_control(self, event=None):
+    def _kube_control(self, event):
         self.kube_control.set_auth_request(self.unit.name)
         return self._merge_config(event)
 
-    def _cluster_tag(self, event=None):
+    def _cluster_tag(self, event):
         cluster_tag = self.kube_control.get_cluster_tag()
         if self.stored.cluster_tag != cluster_tag:
             log.info(f"Updating cluster-tag to {cluster_tag}")
@@ -187,7 +191,7 @@ class AzureCloudProviderCharm(CharmBase):
             return False
         return True
 
-    def _merge_config(self, event=None):
+    def _merge_config(self, event):
         if not self._check_azure_relation(event):
             return
 
@@ -214,22 +218,32 @@ class AzureCloudProviderCharm(CharmBase):
 
         self.stored.config_hash = new_hash
         self.stored.deployed = False
-        self._install_or_upgrade()
+        self._install_or_upgrade(event)
 
-    def _install_or_upgrade(self, _event=None):
+    def _install_or_upgrade(self, event):
         if not self.stored.config_hash:
             return
         self.unit.status = MaintenanceStatus("Deploying Azure Cloud Provider")
         self.unit.set_workload_version("")
         for controller in self.collector.manifests.values():
-            controller.apply_manifests()
+            try:
+                controller.apply_manifests()
+            except ManifestClientError:
+                self.unit.status = WaitingStatus("Waiting for kube-apiserver")
+                event.defer()
+                return
         self.stored.deployed = True
 
-    def _cleanup(self, _event):
+    def _cleanup(self, event):
         if self.stored.config_hash:
             self.unit.status = MaintenanceStatus("Cleaning up Azure Cloud Provider")
             for controller in self.collector.manifests.values():
-                controller.delete_manifests(ignore_unauthorized=True)
+                try:
+                    controller.delete_manifests(ignore_unauthorized=True)
+                except ManifestClientError:
+                    self.unit.status = WaitingStatus("Waiting for kube-apiserver")
+                    event.defer()
+                    return
         self.unit.status = MaintenanceStatus("Shutting down")
 
 

--- a/src/disk_manifests.py
+++ b/src/disk_manifests.py
@@ -17,7 +17,7 @@ from ops.manifests import (
     ManifestLabel,
     Manifests,
     Patch,
-    update_toleration,
+    update_tolerations,
 )
 
 log = logging.getLogger(__file__)
@@ -122,19 +122,20 @@ class UpdateController(Patch):
         "control-node-selector",
     }
 
-    def _adjuster(self, toleration: Toleration) -> List[Toleration]:
+    def _adjuster(self, tolerations: List[Toleration]) -> List[Toleration]:
         node_selector = self.manifests.config.get("control-node-selector", {})
-        if "control-plane" in toleration.key:
-            return [
-                Toleration(
-                    key=key,
-                    value=value,
-                    effect=toleration.effect,
-                    operator="Equal",
-                    tolerationSeconds=toleration.tolerationSeconds,
-                )
-                for key, value in node_selector.items()
-            ]
+        for t in tolerations:
+            if "control-plane" in t.key:
+                return [
+                    Toleration(
+                        key=key,
+                        value=value,
+                        effect=t.effect,
+                        operator="Equal",
+                        tolerationSeconds=t.tolerationSeconds,
+                    )
+                    for key, value in node_selector.items()
+                ]
         return []
 
 
@@ -160,7 +161,7 @@ class UpdateControllerDeployment(UpdateController):
             log.info(f"Replacing azuredisk default replicas of {obj.spec.replicas} to {replicas}")
             obj.spec.replicas = replicas
 
-        update_toleration(obj, self._adjuster)
+        update_tolerations(obj, self._adjuster)
 
 
 class CreateStorageClass(Addition):

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,7 @@ deps =
 commands =
     # uncomment the following line if this charm owns a lib
     # codespell {[vars]lib_path}
-    codespell {toxinidir}/. --skip {toxinidir}/.git --skip {toxinidir}/.tox \
+    codespell {toxinidir} --skip {toxinidir}/.git --skip {toxinidir}/.tox \
       --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
       --skip {toxinidir}/.mypy_cache --skip {toxinidir}/icon.svg \
       --skip {[vars]cov_path} \


### PR DESCRIPTION
This is a set of commits because this repo wasn't squashing commits for a merged PR by default.

I've updated the repo attributes to squash commits now, but in order to prepare this charm for 1.26+ck1, using a PR seems the best way