### PR TITLE
Apply `topologySpreadConstraints` to control-plane Deployments

### DIFF
--- a/src/provider_manifests.py
+++ b/src/provider_manifests.py
@@ -8,7 +8,8 @@ from hashlib import md5
 from typing import Dict, Optional
 
 import humps
-from lightkube.models.core_v1 import Toleration
+from lightkube.models.core_v1 import Toleration, TopologySpreadConstraint
+from lightkube.models.meta_v1 import LabelSelector
 from ops.manifests import ConfigRegistry, ManifestLabel, Manifests, Patch
 
 log = logging.getLogger(__file__)
@@ -164,6 +165,20 @@ class UpdateControllerDeployment(UpdateController):
             log.info(f"Replacing default replicas of {obj.spec.replicas} to {replicas}")
             obj.spec.replicas = replicas
 
+        # to prevents replicas from landing on the same nodes, use topologySpreadConstraints
+        # https://github.com/kubernetes-sigs/cloud-provider-azure/blob/master/helm/cloud-provider-azure/templates/cloud-provider-azure.yaml#L170-L177
+        log.info("Adding provider topologySpreadConstraints")
+
+        # workaround for https://github.com/gtsystem/lightkube/issues/44
+        obj.spec.template.spec._lazy_values.pop("topologySpreadConstraints", None)
+        obj.spec.template.spec.topologySpreadConstraints = [
+            TopologySpreadConstraint(
+                maxSkew=1,
+                topologyKey="kubernetes.io/hostname",
+                whenUnsatisfiable="DoNotSchedule",
+                labelSelector=LabelSelector(matchLabels=dict(**obj.spec.selector.matchLabels)),
+            )
+        ]
         self._update_args(obj.spec.template.spec)
 
 

--- a/src/provider_manifests.py
+++ b/src/provider_manifests.py
@@ -165,8 +165,8 @@ class UpdateControllerDeployment(UpdateController):
             log.info(f"Replacing default replicas of {obj.spec.replicas} to {replicas}")
             obj.spec.replicas = replicas
 
-        # to prevents replicas from landing on the same nodes, use topologySpreadConstraints
-        # https://github.com/kubernetes-sigs/cloud-provider-azure/blob/master/helm/cloud-provider-azure/templates/cloud-provider-azure.yaml#L170-L177
+        # to prevent replicas from landing on the same nodes, use topologySpreadConstraints
+        # https://github.com/kubernetes-sigs/cloud-provider-azure/blob/fe6f72141d63a21525b96873f83e7a1c3dbae39e/helm/cloud-provider-azure/templates/cloud-provider-azure.yaml#L170-L177
         log.info("Adding provider topologySpreadConstraints")
 
         # workaround for https://github.com/gtsystem/lightkube/issues/44

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -167,6 +167,7 @@ def test_waits_for_config(harness, lk_client, caplog):
 
     assert provider_messages == {
         "Adding provider tolerations from control-plane",
+        "Adding provider topologySpreadConstraints",
         'Applying provider Control Node Selector as gcp.io/my-control-node: ""',
         "Replacing default cluster-name to kubernetes-thing",
         "Applying provider secret data",
@@ -184,6 +185,7 @@ def test_waits_for_config(harness, lk_client, caplog):
 
     assert provider_messages == {
         "Adding provider tolerations from control-plane",
+        "Adding provider topologySpreadConstraints",
         'Applying provider Control Node Selector as juju-application: "kubernetes-control-plane"',
         "Replacing default cluster-name to kubernetes-thing",
         "Applying provider secret data",

--- a/upstream/update.py
+++ b/upstream/update.py
@@ -93,10 +93,7 @@ class Release:
 
     def __lt__(self, other) -> bool:
         """Compare version numbers."""
-        a, b, = (
-            self.name[1:],
-            other.name[1:],
-        )
+        a, b = self.name[1:], other.name[1:]
         return VersionInfo.parse(a) < VersionInfo.parse(b)
 
 


### PR DESCRIPTION
When there are more than one kubernetes-control-plane units the azure-cloud-provider charm tries to scale the deployment cloud-controller-manager to 2+ replicas.

The problem arises because it uses hostNetwork, and nothing prevents these replicas from landing on the same controller machines

Following what was done upstream, use `topologySpreadConstraints` to prevent multiple versions of the same pod from landing on each controller

Fixes: https://bugs.launchpad.net/charm-azure-cloud-provider/+bug/2016053