### PR TITLE
using lightkube 0.13.0, this work-around is no longer needed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 backports.cached-property
 pyhumps
-lightkube>=0.10.1,<1.0.0
+lightkube>=0.13.0,<1.0.0
 jsonschema
 ops>=1.3.0,<2.0.0
 pyyaml

--- a/src/disk_manifests.py
+++ b/src/disk_manifests.py
@@ -165,7 +165,6 @@ class UpdateControllerDeployment(UpdateController):
         update_tolerations(obj, self._adjuster)
         log.info("Adding azuredisk topologySpreadConstraints")
 
-        obj.spec.template.spec._lazy_values.pop("topologySpreadConstraints", None)
         obj.spec.template.spec.topologySpreadConstraints = [
             TopologySpreadConstraint(
                 maxSkew=1,

--- a/src/provider_manifests.py
+++ b/src/provider_manifests.py
@@ -169,8 +169,6 @@ class UpdateControllerDeployment(UpdateController):
         # https://github.com/kubernetes-sigs/cloud-provider-azure/blob/fe6f72141d63a21525b96873f83e7a1c3dbae39e/helm/cloud-provider-azure/templates/cloud-provider-azure.yaml#L170-L177
         log.info("Adding provider topologySpreadConstraints")
 
-        # workaround for https://github.com/gtsystem/lightkube/issues/44
-        obj.spec.template.spec._lazy_values.pop("topologySpreadConstraints", None)
         obj.spec.template.spec.topologySpreadConstraints = [
             TopologySpreadConstraint(
                 maxSkew=1,


### PR DESCRIPTION
[LP#2016053](https://launchpad.net/bugs/2016053)
No longer need workaround for https://github.com/gtsystem/lightkube/issues/44

integrations against azure cloud worked successfully